### PR TITLE
Using 'granite-code' model instead of Llama3

### DIFF
--- a/continue-config.json
+++ b/continue-config.json
@@ -8,8 +8,8 @@
         }    
       ],
     "tabAutocompleteModel": {
-      "title": "Starcoder2 3b",
-      "model": "starcoder2:3b",
+      "title": "On-prem Granite-code-8b",
+      "model": "granite-code:8b",
       "provider": "ollama"
     },
     "allowAnonymousTelemetry": false

--- a/continue-config.json
+++ b/continue-config.json
@@ -1,16 +1,16 @@
 {
     "models": [
       {
-        "title": "On-prem Llama3-8b",
-        "model": "llama3:8b",
+        "title": "On-prem Granite-code-8b",
+        "model": "granite-code:8b",
         "apiBase": "http://localhost:11434",
         "provider": "ollama"
         }    
       ],
     "tabAutocompleteModel": {
       "title": "Starcoder2 3b",
-      "provider": "ollama",
-      "model": "starcoder2:3b"
+      "model": "starcoder2:3b",
+      "provider": "ollama"
     },
     "allowAnonymousTelemetry": false
   }

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -40,7 +40,7 @@ commands:
   - id: pullmodel
     exec:
       component: ollama
-      commandLine: "ollama pull llama3:8b"
+      commandLine: "ollama pull granite-code:8b"
   - id: pullautocompletemodel
     exec:
       component: ollama

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -34,10 +34,6 @@ commands:
     exec:
       component: ollama
       commandLine: "ollama pull granite-code:8b"
-  - id: pullautocompletemodel
-    exec:
-      component: ollama
-      commandLine: "ollama pull starcoder2:3b"
   - id: copyconfig
     exec:
       component: udi
@@ -45,5 +41,4 @@ commands:
 events:
   postStart:
     - pullmodel
-    - pullautocompletemodel
     - copyconfig

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -3,13 +3,6 @@ metadata:
   generateName: cde-ollama-continue
 attributes:
   controller.devfile.io/storage-type: ephemeral
-projects:
-  - name: cde-ollama-continue
-    git:
-      remotes:
-        origin: 'https://github.com/redhat-developer-demos/cde-ollama-continue'
-      checkoutFrom:
-        revision: main
 components:
 - name: udi
   container:

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.2.2
+schemaVersion: 2.3.0
 metadata:
   generateName: cde-ollama-continue
 attributes:


### PR DESCRIPTION
Developer Sandbox activity but with the 'granite-code' model https://developers.redhat.com/articles/2024/08/12/integrate-private-ai-coding-assistant-ollama 
<img width="1045" alt="Screenshot 2024-08-13 at 16 09 41" src="https://github.com/user-attachments/assets/f6f2a17b-bea9-4102-ba45-2753bdaa8664">

Model - https://ollama.com/library/granite-code

Click here to review and test on Developer Sandbox: [![Contribute](https://img.shields.io/badge/Eclipse_Che-Hosted%20by%20Red%20Hat-525C86?logo=eclipse-che&labelColor=FDB940)](https://workspaces.openshift.com#https://github.com/redhat-developer-demos/cde-ollama-continue/tree/granite)
