### PR TITLE
Using Llama3.1-8b model with Kubernetes MCP Server

### DIFF
--- a/continue-config.json
+++ b/continue-config.json
@@ -7,11 +7,6 @@
         "provider": "ollama"
         }    
       ],
-    "tabAutocompleteModel": {
-      "title": "Starcoder2 3b",
-      "provider": "ollama",
-      "model": "starcoder2:3b"
-    },
     "allowAnonymousTelemetry": false,
     "experimental": {
       "modelContextProtocolServers": [

--- a/continue-config.json
+++ b/continue-config.json
@@ -1,8 +1,8 @@
 {
     "models": [
       {
-        "title": "On-prem Llama3-8b",
-        "model": "llama3:8b",
+        "title": "On-prem Llama3.1-8b",
+        "model": "llama3.1:8b",
         "apiBase": "http://localhost:11434",
         "provider": "ollama"
         }    
@@ -12,5 +12,16 @@
       "provider": "ollama",
       "model": "starcoder2:3b"
     },
-    "allowAnonymousTelemetry": false
+    "allowAnonymousTelemetry": false,
+    "experimental": {
+      "modelContextProtocolServers": [
+        {
+          "transport": {
+            "type": "stdio",
+            "command": "npx",
+            "args": ["-y", "kubernetes-mcp-server@latest"]
+          }
+        }
+      ]
+    }
   }

--- a/continue-config.json
+++ b/continue-config.json
@@ -1,8 +1,8 @@
 {
     "models": [
       {
-        "title": "On-prem Llama3.1-70b",
-        "model": "llama3.1:70b",
+        "title": "On-prem Llama3.1-8b",
+        "model": "llama3.1:8b",
         "apiBase": "http://localhost:11434",
         "provider": "ollama"
         }    

--- a/continue-config.json
+++ b/continue-config.json
@@ -1,8 +1,8 @@
 {
     "models": [
       {
-        "title": "On-prem Llama3.1-8b",
-        "model": "llama3.1:8b",
+        "title": "On-prem Llama3.1-70b",
+        "model": "llama3.1:70b",
         "apiBase": "http://localhost:11434",
         "provider": "ollama"
         }    

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -3,13 +3,6 @@ metadata:
   generateName: cde-ollama-continue
 attributes:
   controller.devfile.io/storage-type: ephemeral
-projects:
-  - name: cde-ollama-continue
-    git:
-      remotes:
-        origin: 'https://github.com/redhat-developer-demos/cde-ollama-continue'
-      checkoutFrom:
-        revision: main
 components:
 - name: udi
   container:
@@ -40,7 +33,7 @@ commands:
   - id: pullmodel
     exec:
       component: ollama
-      commandLine: "ollama pull llama3:8b"
+      commandLine: "ollama pull llama3.1:8b"
   - id: pullautocompletemodel
     exec:
       component: ollama

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -45,5 +45,4 @@ commands:
 events:
   postStart:
     - pullmodel
-    - pullautocompletemodel
     - copyconfig

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -33,7 +33,7 @@ commands:
   - id: pullmodel
     exec:
       component: ollama
-      commandLine: "ollama pull llama3.1:8b"
+      commandLine: "ollama pull llama3.1:70b"
   - id: pullautocompletemodel
     exec:
       component: ollama

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -20,11 +20,11 @@ components:
         limits:
           cpu: 4000m
           memory: 12Gi
-          # nvidia.com/gpu: 1 # Uncomment this if the pod shall be scheduled only on a GPU node
+          nvidia.com/gpu: 1 # Uncomment this if the pod shall be scheduled only on a GPU node
         requests:
           cpu: 1000m
           memory: 8Gi
-          # nvidia.com/gpu: 1 # Uncomment this if the pod shall be scheduled only on a GPU node
+          nvidia.com/gpu: 1 # Uncomment this if the pod shall be scheduled only on a GPU node
   container:
     image: docker.io/ollama/ollama:latest
     mountSources: true

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -33,7 +33,7 @@ commands:
   - id: pullmodel
     exec:
       component: ollama
-      commandLine: "ollama pull llama3.1:70b"
+      commandLine: "ollama pull llama3.1:8b"
   - id: pullautocompletemodel
     exec:
       component: ollama


### PR DESCRIPTION
Related JIRA - https://issues.redhat.com/browse/CRW-8005 

MCP server from @manusa is used https://github.com/manusa/kubernetes-mcp-server/ 

<img width="319" alt="Screenshot 2025-04-15 at 17 17 25" src="https://github.com/user-attachments/assets/c951662f-b549-4b86-8257-133a7b40d978" />


<img width="319" alt="Screenshot 2025-04-15 at 17 16 53" src="https://github.com/user-attachments/assets/1d3aaebd-8e1e-4f73-8b74-3b4a72200b81" />

- in order to try it out, you need a cluster with GPU nodes available (Developer Sandbox does not have it and 'Tools' / 'Agents' requests are timing out)
- 'ollama' provider is used since 'openai' is not currently supported by Continue - https://github.com/continuedev/continue/issues/5044
- `llama3.1` with `70b` will not work on clusters like Developer Sandbox, hence we can use only `8b`
<img width="503" alt="Screenshot 2025-04-07 at 13 40 12" src="https://github.com/user-attachments/assets/53092d4b-0f47-4527-a443-8a13f2995598" />

TODO: make the same flow work with
- Granite 3.2 - https://github.com/redhat-developer-demos/cde-ollama-continue/pull/13
- Granite 3.3 - https://github.com/redhat-developer-demos/cde-ollama-continue/pull/15

